### PR TITLE
srun --label support: pass --label when label_io=True

### DIFF
--- a/produtil/mpi_impl/srun.py
+++ b/produtil/mpi_impl/srun.py
@@ -121,7 +121,7 @@ class Implementation(ImplementationBase):
             available_nodes.append(node)
         return available_nodes
     
-    def mpirunner_impl(self,arg,allranks=False,rewrite_nodefile=True,**kwargs):
+    def mpirunner_impl(self,arg,allranks=False,rewrite_nodefile=True,label_io=False,**kwargs):
         """!This is the underlying implementation of mpirunner and should
         not be called directly."""
         assert(isinstance(arg,produtil.mpiprog.MPIRanksBase))
@@ -138,6 +138,9 @@ class Implementation(ImplementationBase):
 
 
         srun_args=[self.srun_path,'--export=ALL','--cpu_bind=core']
+
+        if label_io:
+            srun_args.append('--label')
     
         if arg.nranks()==1 and allranks:
             srun_args.append('--distribution=block:block')

--- a/produtil/mpi_impl/srun_shell.py
+++ b/produtil/mpi_impl/srun_shell.py
@@ -96,7 +96,7 @@ class Implementation(ImplementationBase):
             logging.getLogger('srun').info("%s => %s"%(repr(arg),repr(f)))
         return f
     
-    def mpirunner_impl(self,arg,allranks=False,nodesize=None,**kwargs):
+    def mpirunner_impl(self,arg,allranks=False,nodesize=None,label_io=False,**kwargs):
         """!This is the underlying implementation of mpirunner and should
         not be called directly."""
         if not nodesize:
@@ -118,6 +118,9 @@ class Implementation(ImplementationBase):
 
 
         srun_args=['srun','--export=ALL','--cpu_bind=core']
+
+        if label_io:
+            srun_args.append('--label')
 
         arbitrary_pl=list()
         layout_pl=list()


### PR DESCRIPTION
The srun.py and srun_shell.py were ignoring the label_io option. This corrects that bug: when `label_io=True`, it adds the `--label` option to the srun command.

This is needed for a bug fix to the NEMSCompsetRun, requested by dom.heinzeller@noaa.gov

This NEMS PR updates the produtil submodule to point to the hash of this produtil version:

- https://github.com/NOAA-EMC/NEMS/pull/47